### PR TITLE
Implement basic Telegram WebApp bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# community-swiper
+# Community Swiper
+
+This repository contains a basic skeleton for a Telegram WebApp bot that allows members of a closed community to swipe profiles and see matches. The project uses **FastAPI** for the backend and **PostgreSQL** for persistence.
+
+## Components
+
+- **Backend** (`app/`): FastAPI application with endpoints for authentication, swiping and listing matches.
+- **Telegram Bot** (`bot/`): minimal bot that opens the WebApp inside Telegram.
+- **WebApp** (`webapp/`): HTML/JavaScript interface for performing swipe actions.
+
+## Quick start
+
+1. Install dependencies (preferably inside a virtual environment):
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set the `DATABASE_URL` environment variable pointing to your PostgreSQL instance, e.g.:
+
+```bash
+export DATABASE_URL=postgresql://user:password@localhost/swiper
+```
+
+3. Run the backend:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+4. Launch the bot:
+
+```bash
+python bot/bot.py
+```
+
+5. Open the WebApp link provided by the bot and start swiping.
+
+This is only a starting point and does not implement the full business logic yet. Contributions are welcome.

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,45 @@
+from sqlalchemy.orm import Session
+from . import models, schemas
+
+
+def get_user_by_telegram_id(db: Session, telegram_id: int):
+    return db.query(models.User).filter(models.User.telegram_id == telegram_id).first()
+
+
+def create_user(db: Session, user: schemas.UserCreate):
+    db_user = models.User(**user.dict())
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def get_random_profile(db: Session, exclude_id: int):
+    return (
+        db.query(models.User)
+        .filter(models.User.id != exclude_id)
+        .order_by(models.User.id)
+        .first()
+    )
+
+
+def create_swipe(db: Session, from_user_id: int, swipe: schemas.SwipeCreate):
+    db_swipe = models.Swipe(from_user_id=from_user_id, **swipe.dict())
+    db.add(db_swipe)
+    db.commit()
+    db.refresh(db_swipe)
+    return db_swipe
+
+
+def get_matches(db: Session, user_id: int):
+    return (
+        db.query(models.User)
+        .join(models.Swipe, models.Swipe.to_user_id == models.User.id)
+        .filter(models.Swipe.from_user_id == user_id, models.Swipe.is_like == True)
+        .join(
+            models.Swipe,
+            (models.Swipe.from_user_id == models.User.id) & (models.Swipe.to_user_id == user_id) & (models.Swipe.is_like == True),
+            isouter=False,
+        )
+        .all()
+    )

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///./test.db')
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith('sqlite') else {})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/app/import_from_csv.py
+++ b/app/import_from_csv.py
@@ -1,0 +1,31 @@
+import csv
+from sqlalchemy.orm import Session
+from .db import SessionLocal, engine
+from . import models
+
+models.Base.metadata.create_all(bind=engine)
+
+def import_csv(path: str):
+    db: Session = SessionLocal()
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            user = models.User(
+                telegram_id=int(row['telegram_id']),
+                name=row['name'],
+                username=row.get('username'),
+                city=row.get('city'),
+                sphere=row.get('sphere'),
+                description=row.get('description'),
+                category=row.get('category'),
+            )
+            db.add(user)
+        db.commit()
+    db.close()
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('csv_path')
+    args = parser.parse_args()
+    import_csv(args.csv_path)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from . import models, schemas, crud
+from .db import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Community Swiper")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@ app.post('/auth', response_model=schemas.User)
+def auth(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = crud.get_user_by_telegram_id(db, user.telegram_id)
+    if db_user:
+        return db_user
+    else:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+@ app.get('/profiles/random', response_model=schemas.User)
+def random_profile(user_id: int, db: Session = Depends(get_db)):
+    profile = crud.get_random_profile(db, user_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="No profiles available")
+    return profile
+
+
+@ app.post('/swipe')
+def swipe(user_id: int, swipe: schemas.SwipeCreate, db: Session = Depends(get_db)):
+    return crud.create_swipe(db, user_id, swipe)
+
+
+@ app.get('/matches', response_model=list[schemas.User])
+def matches(user_id: int, db: Session = Depends(get_db)):
+    return crud.get_matches(db, user_id)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True, index=True)
+    telegram_id = Column(Integer, unique=True, index=True, nullable=False)
+    name = Column(String, nullable=False)
+    username = Column(String, nullable=True)
+    city = Column(String, nullable=True)
+    sphere = Column(String, nullable=True)
+    description = Column(String, nullable=True)
+    category = Column(String, nullable=True)
+
+    likes_sent = relationship('Swipe', back_populates='from_user', foreign_keys='Swipe.from_user_id')
+    likes_received = relationship('Swipe', back_populates='to_user', foreign_keys='Swipe.to_user_id')
+
+class Swipe(Base):
+    __tablename__ = 'swipes'
+
+    id = Column(Integer, primary_key=True)
+    from_user_id = Column(Integer, ForeignKey('users.id'))
+    to_user_id = Column(Integer, ForeignKey('users.id'))
+    is_like = Column(Boolean, default=False)
+
+    from_user = relationship('User', back_populates='likes_sent', foreign_keys=[from_user_id])
+    to_user = relationship('User', back_populates='likes_received', foreign_keys=[to_user_id])

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class UserBase(BaseModel):
+    telegram_id: int
+    name: str
+    username: Optional[str]
+    city: Optional[str]
+    sphere: Optional[str]
+    description: Optional[str]
+    category: Optional[str]
+
+class UserCreate(UserBase):
+    pass
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class SwipeCreate(BaseModel):
+    to_user_id: int
+    is_like: bool

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,0 +1,22 @@
+import os
+from aiogram import Bot, Dispatcher, types
+from aiogram.utils import executor
+from dotenv import load_dotenv
+
+load_dotenv()
+API_TOKEN = os.getenv('BOT_TOKEN')
+WEBAPP_URL = os.getenv('WEBAPP_URL', 'https://example.com')
+
+bot = Bot(token=API_TOKEN)
+dp = Dispatcher(bot)
+
+
+@dp.message_handler(commands=['start'])
+async def send_welcome(message: types.Message):
+    keyboard = types.InlineKeyboardMarkup()
+    keyboard.add(types.InlineKeyboardButton("Open", web_app=types.WebAppInfo(url=WEBAPP_URL)))
+    await message.reply("Welcome!", reply_markup=keyboard)
+
+
+if __name__ == '__main__':
+    executor.start_polling(dp, skip_updates=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+SQLAlchemy
+pydantic
+aiogram
+python-dotenv
+psycopg2-binary

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Community Swiper</title>
+  <script src="script.js" defer></script>
+</head>
+<body>
+  <div id="profile"></div>
+  <button id="like">Like</button>
+  <button id="skip">Skip</button>
+</body>
+</html>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const profileDiv = document.getElementById('profile');
+  const likeBtn = document.getElementById('like');
+  const skipBtn = document.getElementById('skip');
+  let currentProfile = null;
+
+  async function loadProfile() {
+    const userId = Telegram.WebApp.initDataUnsafe?.user?.id;
+    const response = await fetch(`/profiles/random?user_id=${userId}`);
+    if (response.ok) {
+      currentProfile = await response.json();
+      profileDiv.innerText = `${currentProfile.name} - ${currentProfile.city || ''}`;
+    } else {
+      profileDiv.innerText = 'No profiles';
+    }
+  }
+
+  async function swipe(isLike) {
+    if (!currentProfile) return;
+    const userId = Telegram.WebApp.initDataUnsafe?.user?.id;
+    await fetch(`/swipe?user_id=${userId}`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({to_user_id: currentProfile.id, is_like: isLike})
+    });
+    loadProfile();
+  }
+
+  likeBtn.addEventListener('click', () => swipe(true));
+  skipBtn.addEventListener('click', () => swipe(false));
+
+  loadProfile();
+});


### PR DESCRIPTION
## Summary
- add project description and quick start instructions
- declare Python dependencies
- implement FastAPI backend with DB models and CRUD logic
- provide Telegram bot entry point
- create simple HTML/JS WebApp for swiping
- helper script for importing members from CSV

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c2e935e48325a648384871d065d1